### PR TITLE
Add gardening helper app

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,19 @@
 | Prompting style    | Natural language               | Minimal (tab completion)   |
 | Custom workflows   | ✅ (flexible via chat)          | ❌                          |
 | Debugging help     | ✅                              | ❌                          |
+
+## Gardening App
+
+This repository now includes a minimal gardening helper. It stores common plant information and can send email reminders.
+
+### Usage
+
+Run the command line interface:
+
+```bash
+python -m garden_app list
+python -m garden_app info tomato
+python -m garden_app schedule tomato you@example.com 2024-04-01 --simulate
+```
+
+Set `SMTP_SERVER`, `SMTP_PORT`, `SMTP_USER`, and `SMTP_PASS` environment variables to send real emails. Use `--simulate` to print the messages instead.

--- a/garden_app/__init__.py
+++ b/garden_app/__init__.py
@@ -1,0 +1,1 @@
+"""Garden helper package."""

--- a/garden_app/__main__.py
+++ b/garden_app/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/garden_app/cli.py
+++ b/garden_app/cli.py
@@ -1,0 +1,60 @@
+import argparse
+from datetime import datetime
+
+from .data import load_plants
+from .scheduler import send_schedule
+
+
+def list_plants():
+    plants = load_plants()
+    for name, info in plants.items():
+        print(f"{name.title()} ({info['type']})")
+
+
+def plant_info(name: str):
+    plants = load_plants()
+    info = plants.get(name)
+    if not info:
+        print(f"Unknown plant '{name}'")
+        return
+    print(f"Information for {name}:")
+    for key, value in info.items():
+        print(f"  {key.replace('_', ' ').title()}: {value}")
+
+
+def schedule(name: str, email: str, start: str, simulate: bool):
+    start_date = datetime.fromisoformat(start)
+    schedule = send_schedule(email, name, start_date, simulate=simulate)
+    for date, msg in schedule:
+        print(f"Scheduled reminder {date.date()}: {msg}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple gardening helper")
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("list", help="List available plants")
+
+    info_p = sub.add_parser("info", help="Show info for plant")
+    info_p.add_argument("name")
+
+    sched_p = sub.add_parser("schedule", help="Schedule email reminders")
+    sched_p.add_argument("name")
+    sched_p.add_argument("email")
+    sched_p.add_argument("start", help="Start date YYYY-MM-DD")
+    sched_p.add_argument("--simulate", action="store_true", help="Print emails instead of sending")
+
+    args = parser.parse_args()
+
+    if args.command == "list":
+        list_plants()
+    elif args.command == "info":
+        plant_info(args.name)
+    elif args.command == "schedule":
+        schedule(args.name, args.email, args.start, args.simulate)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/garden_app/data.py
+++ b/garden_app/data.py
@@ -1,0 +1,9 @@
+import json
+from pathlib import Path
+
+DATA_FILE = Path(__file__).with_name('plants.json')
+
+
+def load_plants():
+    with DATA_FILE.open() as f:
+        return json.load(f)

--- a/garden_app/email_util.py
+++ b/garden_app/email_util.py
@@ -1,0 +1,29 @@
+import os
+import smtplib
+from email.message import EmailMessage
+
+SMTP_SERVER = os.getenv('SMTP_SERVER', 'localhost')
+SMTP_PORT = int(os.getenv('SMTP_PORT', '25'))
+SMTP_USER = os.getenv('SMTP_USER')
+SMTP_PASS = os.getenv('SMTP_PASS')
+
+def send_email(to_email: str, subject: str, body: str, simulate: bool = False) -> None:
+    """Send an email or print it in simulate mode."""
+    msg = EmailMessage()
+    msg['From'] = SMTP_USER or 'garden-app@example.com'
+    msg['To'] = to_email
+    msg['Subject'] = subject
+    msg.set_content(body)
+
+    if simulate:
+        print('--- Simulated email ---')
+        print('To:', to_email)
+        print('Subject:', subject)
+        print(body)
+        print('-----------------------')
+        return
+
+    with smtplib.SMTP(SMTP_SERVER, SMTP_PORT) as server:
+        if SMTP_USER and SMTP_PASS:
+            server.login(SMTP_USER, SMTP_PASS)
+        server.send_message(msg)

--- a/garden_app/plants.json
+++ b/garden_app/plants.json
@@ -1,0 +1,34 @@
+{
+  "tomato": {
+    "type": "vegetable",
+    "seed_start": "6-8 weeks before last frost",
+    "transplant_outdoors": "after danger of frost",
+    "fertilization": "every 2-3 weeks with balanced fertilizer",
+    "notes": "Prefers full sun and well-drained soil."
+  },
+  "cucumber": {
+    "type": "vegetable",
+    "seed_start": "direct sow after last frost",
+    "fertilization": "monthly with compost tea",
+    "notes": "Provide trellis support."
+  },
+  "lettuce": {
+    "type": "vegetable",
+    "seed_start": "2-4 weeks before last frost",
+    "fertilization": "light feeding at planting",
+    "notes": "Prefers cool weather."
+  },
+  "rose": {
+    "type": "flower",
+    "seed_start": "propagate from cuttings or buy bare root",
+    "fertilization": "spring and mid-summer",
+    "notes": "Prune in early spring."
+  },
+  "marigold": {
+    "type": "flower",
+    "seed_start": "4-6 weeks before last frost",
+    "transplant_outdoors": "after danger of frost",
+    "fertilization": "at planting and mid-season",
+    "notes": "Great companion plant."
+  }
+}

--- a/garden_app/scheduler.py
+++ b/garden_app/scheduler.py
@@ -1,0 +1,31 @@
+from datetime import datetime, timedelta
+from typing import Dict, List
+
+from .email_util import send_email
+from .data import load_plants
+
+
+def build_schedule(plant_info: Dict[str, str], start_date: datetime) -> List[tuple]:
+    """Return list of (date, message) tuples for reminders."""
+    reminders = []
+    seed_start = plant_info.get('seed_start')
+    if seed_start:
+        reminders.append((start_date, f"Start {plant_info['type']} '{plant_info}': {seed_start}"))
+    fert = plant_info.get('fertilization')
+    if fert:
+        fert_date = start_date + timedelta(days=30)
+        reminders.append((fert_date, f"Fertilize {plant_info['type']} '{plant_info}': {fert}"))
+    return reminders
+
+
+def send_schedule(email: str, plant_name: str, start_date: datetime, simulate: bool = False) -> List[tuple]:
+    plants = load_plants()
+    info = plants.get(plant_name)
+    if not info:
+        raise ValueError(f"Unknown plant '{plant_name}'")
+    schedule = build_schedule(info, start_date)
+    for date, msg in schedule:
+        subject = f"Gardening reminder for {plant_name}"
+        body = f"Reminder for {date.date()}: {msg}"
+        send_email(email, subject, body, simulate=simulate)
+    return schedule

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,9 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from garden_app.data import load_plants
+
+
+def test_load_plants():
+    plants = load_plants()
+    assert 'tomato' in plants
+    assert plants['tomato']['type'] == 'vegetable'

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,13 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from datetime import datetime
+from garden_app.scheduler import build_schedule
+from garden_app.data import load_plants
+
+
+def test_build_schedule():
+    plants = load_plants()
+    start = datetime(2023, 4, 1)
+    schedule = build_schedule(plants['tomato'], start)
+    assert schedule
+    assert any('Fertilize' in m for _, m in schedule)


### PR DESCRIPTION
## Summary
- add a minimal gardening helper that stores plant info
- schedule email reminders with configurable SMTP settings
- command line tool to list plants, display details, and send reminders
- tests for data loader and schedule logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687407d4cbac832fa8144290ef8d1707