### PR TITLE
Add simple Tkinter GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Run the command line interface:
 python -m garden_app list
 python -m garden_app info tomato
 python -m garden_app schedule tomato you@example.com 2024-04-01 --simulate
+python -m garden_app gui  # launch simple GUI (if Tkinter available)
 ```
 
 Set `SMTP_SERVER`, `SMTP_PORT`, `SMTP_USER`, and `SMTP_PASS` environment variables to send real emails. Use `--simulate` to print the messages instead.

--- a/garden_app/cli.py
+++ b/garden_app/cli.py
@@ -4,6 +4,12 @@ from datetime import datetime
 from .data import load_plants
 from .scheduler import send_schedule
 
+# Optional GUI support
+try:
+    from .gui import run_gui
+except Exception:
+    run_gui = None
+
 
 def list_plants():
     plants = load_plants()
@@ -42,7 +48,12 @@ def main():
     sched_p.add_argument("name")
     sched_p.add_argument("email")
     sched_p.add_argument("start", help="Start date YYYY-MM-DD")
-    sched_p.add_argument("--simulate", action="store_true", help="Print emails instead of sending")
+    sched_p.add_argument(
+        "--simulate", action="store_true", help="Print emails instead of sending"
+    )
+
+    if run_gui:
+        sub.add_parser("gui", help="Launch graphical interface")
 
     args = parser.parse_args()
 
@@ -52,6 +63,8 @@ def main():
         plant_info(args.name)
     elif args.command == "schedule":
         schedule(args.name, args.email, args.start, args.simulate)
+    elif args.command == "gui" and run_gui:
+        run_gui()
     else:
         parser.print_help()
 

--- a/garden_app/gui.py
+++ b/garden_app/gui.py
@@ -1,0 +1,70 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+from datetime import datetime
+
+from .data import load_plants
+from .scheduler import send_schedule
+
+
+def run_gui():
+    """Launch a simple Tkinter interface for the garden app."""
+    plants = load_plants()
+    if not plants:
+        raise RuntimeError("No plant data available")
+
+    root = tk.Tk()
+    root.title("Garden Helper")
+
+    plant_var = tk.StringVar(value=list(plants.keys())[0])
+
+    def update_info(*_):
+        info = plants.get(plant_var.get(), {})
+        lines = []
+        for key, value in info.items():
+            lines.append(f"{key.replace('_', ' ').title()}: {value}")
+        info_box.config(state="normal")
+        info_box.delete("1.0", tk.END)
+        info_box.insert(tk.END, "\n".join(lines))
+        info_box.config(state="disabled")
+
+    plant_menu = ttk.Combobox(root, textvariable=plant_var, values=list(plants.keys()))
+    plant_menu.pack(padx=10, pady=5)
+    plant_menu.bind("<<ComboboxSelected>>", update_info)
+
+    info_box = tk.Text(root, width=50, height=10)
+    info_box.pack(padx=10, pady=5)
+    info_box.config(state="disabled")
+
+    email_var = tk.StringVar()
+    start_var = tk.StringVar()
+
+    tk.Label(root, text="Email:").pack()
+    tk.Entry(root, textvariable=email_var).pack(fill="x", padx=10)
+
+    tk.Label(root, text="Start date YYYY-MM-DD:").pack()
+    tk.Entry(root, textvariable=start_var).pack(fill="x", padx=10)
+
+    def do_schedule():
+        try:
+            start_date = datetime.fromisoformat(start_var.get())
+        except ValueError:
+            messagebox.showerror("Invalid date", "Enter a valid date YYYY-MM-DD")
+            return
+        try:
+            schedule = send_schedule(
+                email_var.get(), plant_var.get(), start_date, simulate=True
+            )
+        except Exception as exc:
+            messagebox.showerror("Error", str(exc))
+            return
+        msg = "\n".join(f"{d.date()}: {m}" for d, m in schedule)
+        messagebox.showinfo("Schedule", f"Scheduled reminders (simulated):\n{msg}")
+
+    tk.Button(root, text="Send schedule (simulate)", command=do_schedule).pack(pady=10)
+
+    update_info()
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    run_gui()


### PR DESCRIPTION
## Summary
- add `gui` subcommand to CLI
- provide new `gui.py` Tkinter-based interface
- document running the GUI in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687805f6e8cc832f96ef53e0e85204f6