### PR TITLE
Fix plant name in schedule messages

### DIFF
--- a/garden_app/scheduler.py
+++ b/garden_app/scheduler.py
@@ -5,16 +5,20 @@ from .email_util import send_email
 from .data import load_plants
 
 
-def build_schedule(plant_info: Dict[str, str], start_date: datetime) -> List[tuple]:
+def build_schedule(plant_info: Dict[str, str], start_date: datetime, plant_name: str) -> List[tuple]:
     """Return list of (date, message) tuples for reminders."""
     reminders = []
     seed_start = plant_info.get('seed_start')
     if seed_start:
-        reminders.append((start_date, f"Start {plant_info['type']} '{plant_info}': {seed_start}"))
+        reminders.append(
+            (start_date, f"Start {plant_name} ({plant_info['type']}): {seed_start}")
+        )
     fert = plant_info.get('fertilization')
     if fert:
         fert_date = start_date + timedelta(days=30)
-        reminders.append((fert_date, f"Fertilize {plant_info['type']} '{plant_info}': {fert}"))
+        reminders.append(
+            (fert_date, f"Fertilize {plant_name} ({plant_info['type']}): {fert}")
+        )
     return reminders
 
 
@@ -23,7 +27,7 @@ def send_schedule(email: str, plant_name: str, start_date: datetime, simulate: b
     info = plants.get(plant_name)
     if not info:
         raise ValueError(f"Unknown plant '{plant_name}'")
-    schedule = build_schedule(info, start_date)
+    schedule = build_schedule(info, start_date, plant_name)
     for date, msg in schedule:
         subject = f"Gardening reminder for {plant_name}"
         body = f"Reminder for {date.date()}: {msg}"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -8,6 +8,7 @@ from garden_app.data import load_plants
 def test_build_schedule():
     plants = load_plants()
     start = datetime(2023, 4, 1)
-    schedule = build_schedule(plants['tomato'], start)
+    schedule = build_schedule(plants['tomato'], start, 'tomato')
     assert schedule
     assert any('Fertilize' in m for _, m in schedule)
+    assert all('tomato' in m for _, m in schedule)


### PR DESCRIPTION
## Summary
- include plant name when building schedules
- update tests for new build_schedule signature

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878186f5840832fa7ef76d683541dd7