### PR TITLE
Add basic Flask support chatbot

### DIFF
--- a/support_chatbot_app/app.py
+++ b/support_chatbot_app/app.py
@@ -1,0 +1,18 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+
+app = Flask(__name__)
+CORS(app)
+
+
+@app.route('/support', methods=['POST'])
+def support():
+    data = request.get_json(force=True)
+    message = data.get('message', '')
+    # In the future, integrate with the OpenAI API here using `message`.
+    response_text = "Thanks for your message. A support agent will contact you soon."
+    return jsonify({'response': response_text})
+
+
+if __name__ == '__main__':
+    app.run(port=5000)


### PR DESCRIPTION
## Summary
- add `support_chatbot_app` with a Flask `/support` endpoint
- allow CORS and return a dummy support message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891131935bc832f8d8e0fe5beed032a