### PR TITLE
Add AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Purpose and Scope
+This file provides instructions or tips for agents working in this repository. The scope of this file covers the entire repository and all nested directories.
+
+## Coding and Style Guidelines
+### Python
+- Follow [PEP 8](https://peps.python.org/pep-0008/).
+- Use descriptive variable and function names.
+
+### JavaScript/TypeScript
+- Use ES6+ syntax.
+- Prefer functional components and hooks in React.
+
+## Testing and Tooling
+- Run `pytest` from the repository root after making changes.
+- For the React apps in `ai_dashboard_app` and `home_gardening_app`, run `npm run lint` inside each app to ensure code style.
+
+## Repository Conventions
+- Commit messages should begin with a short imperative phrase, e.g., "Add feature X".
+- Work directly on the default branch; do not create new branches.
+
+## Notes for Pull Requests
+- Summarize the change and reference relevant issues.
+- Include a brief summary of test or lint results in the PR description.
+
+## Updating This File
+Future contributors are encouraged to expand or clarify these instructions as the repository evolves.


### PR DESCRIPTION
## Summary
- add AGENTS.md with repository instructions

## Testing
- `pytest`
- `npm run lint` (ai_dashboard_app)
- `npm run lint` (home_gardening_app)


------
https://chatgpt.com/codex/tasks/task_e_689120004cf0832f9eef6aa588721c45